### PR TITLE
Updated to work with ROS 2 rolling (probably soon-to-be jazzy).

### DIFF
--- a/apriltag_ros/config/params.yaml
+++ b/apriltag_ros/config/params.yaml
@@ -18,4 +18,4 @@
     queue_size: 1
     tag_detections_topic: "tag_detections"
     tag_detections_image_topic: "tag_detections_image"
-    remove_dupicates: true
+    remove_duplicates: true

--- a/apriltag_ros/include/apriltag_ros/common_functions.hpp
+++ b/apriltag_ros/include/apriltag_ros/common_functions.hpp
@@ -60,7 +60,7 @@
 #include "std_msgs/msg/header.hpp"
 
 // Image related
-#include <cv_bridge/cv_bridge.h>
+#include <cv_bridge/cv_bridge.hpp>
 #include <eigen3/Eigen/Dense>
 #include <eigen3/Eigen/Geometry>
 #include <opencv2/opencv.hpp>

--- a/apriltag_ros/include/apriltag_ros/continuous_detector.hpp
+++ b/apriltag_ros/include/apriltag_ros/continuous_detector.hpp
@@ -51,7 +51,7 @@
 #include "apriltag_ros/composition_visibility.h"
 
 #include <rclcpp/rclcpp.hpp>
-#include <cv_bridge/cv_bridge.h>
+#include <cv_bridge/cv_bridge.hpp>
 #include <image_transport/image_transport.hpp>
 
 // Own

--- a/apriltag_ros/src/common_functions.cpp
+++ b/apriltag_ros/src/common_functions.cpp
@@ -30,7 +30,7 @@
  */
 
 #include "apriltag_ros/common_functions.hpp"
-#include "image_geometry/pinhole_camera_model.h"
+#include "image_geometry/pinhole_camera_model.hpp"
 
 #include "apriltag/common/homography.h"
 #include "apriltag/tagStandard52h13.h"
@@ -279,11 +279,12 @@ apriltag_ros_interfaces::msg::AprilTagDetectionArray TagDetector::detectTags (
     {
         cv::cvtColor(image->image, gray_image, CV_BGR2GRAY);
     }
-    image_u8_t apriltag_image = { .width = gray_image.cols,
-                                    .height = gray_image.rows,
-                                    .stride = gray_image.cols,
-                                    .buf = gray_image.data
-    };
+
+    image_u8_t apriltag_image = {
+        gray_image.cols,    // width
+        gray_image.rows,    // height
+        gray_image.cols,    // stride
+        gray_image.data};   // buf
 
     image_geometry::PinholeCameraModel camera_model;
     camera_model.fromCameraInfo(camera_info);

--- a/apriltag_ros/src/continuous_detector.cpp
+++ b/apriltag_ros/src/continuous_detector.cpp
@@ -30,7 +30,6 @@
  */
 
 #include "apriltag_ros/continuous_detector.hpp"
-#include <ament_index_cpp/get_package_share_directory.hpp>
 
 
 using namespace apriltag_ros;

--- a/apriltag_ros/src/single_image_detector.cpp
+++ b/apriltag_ros/src/single_image_detector.cpp
@@ -35,7 +35,7 @@
 
 #include <opencv2/highgui/highgui.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
-#include <cv_bridge/cv_bridge.h>
+#include <cv_bridge/cv_bridge.hpp>
 
 using std::placeholders::_1;
 using std::placeholders::_2;


### PR DESCRIPTION
I'm running ROS `jazzy` on Ubuntu 24. There is no `jazzy` branch of [ros-perception/vision_opencv](https://github.com/ros-perception/vision_opencv/tree/rolling) , so I used the `rolling` branch, which I presume will eventually be back-ported to a new `jazzy` branch. 
* The `rolling` branch has removed a couple of C-style headers, and the changes to `apriltag_ros` in this PR address this. 
* Fixed a typo.
* Got rid of a C++ 20 feature, since `CMakeLists.txt` says to default to C++ 14.

Thanks a million for the `ros2` branch, saved me a lot of time.